### PR TITLE
Edit esphome.name to be dns name compliant

### DIFF
--- a/esphome.yaml
+++ b/esphome.yaml
@@ -1,5 +1,5 @@
 esphome:
-  name: esp_linky
+  name: esp-linky
   platform: ESP8266
   board: d1_mini
 

--- a/esphome/esphome-BASE.yaml
+++ b/esphome/esphome-BASE.yaml
@@ -1,5 +1,5 @@
 esphome:
-  name: esp_linky
+  name: esp-linky
   platform: ESP8266
   board: d1_mini
 

--- a/esphome/esphome-HPHC.yaml
+++ b/esphome/esphome-HPHC.yaml
@@ -1,5 +1,5 @@
 esphome:
-  name: esp_linky
+  name: esp-linky
   platform: ESP8266
   board: d1_mini
 


### PR DESCRIPTION
Je vous propose cette PR afin de ne plus avoir de warning dans esp home.
J'ai changé le nom esp_linky par esp-linky.
En effet, ce nom est aussi utilisé pour communiqué sur le réseau par son nom dns.
Un nom DNS ne doit pas comprendre de "_" cela peut amener à certains problèmes