### PR TITLE
Fix state_class

### DIFF
--- a/esphome/esphome-BASE.yaml
+++ b/esphome/esphome-BASE.yaml
@@ -29,7 +29,7 @@ uart:
   data_bits: 7
 
 
-#setup teleinfo, update valut every 60s
+#setup teleinfo, update value every 60s
 teleinfo:
   id: myteleinfo
   update_interval: 60s
@@ -42,7 +42,7 @@ sensor:
     tag_name: "BASE"
     name: "Linky BASE"
     teleinfo_id: myteleinfo
-    state_class: "measurement"
+    state_class: "total_increasing"
     device_class: "energy"
     unit_of_measurement: "Wh"
 

--- a/esphome/esphome-HPHC.yaml
+++ b/esphome/esphome-HPHC.yaml
@@ -29,7 +29,7 @@ uart:
   data_bits: 7
 
 
-#setup teleinfo, update valut every 60s
+#setup teleinfo, update value every 60s
 teleinfo:
   id: myteleinfo
   update_interval: 60s
@@ -42,7 +42,7 @@ sensor:
     tag_name: "HCHC"
     name: "Linky HC"
     teleinfo_id: myteleinfo
-    state_class: "measurement"
+    state_class: "total_increasing"
     device_class: "energy"
     unit_of_measurement: "Wh"
   
@@ -51,7 +51,7 @@ sensor:
     tag_name: "HCHP"
     name: "Linky HP"
     teleinfo_id: myteleinfo
-    state_class: "measurement"
+    state_class: "total_increasing"
     device_class: "energy"
     unit_of_measurement: "Wh"
 


### PR DESCRIPTION
The state_class should be `total` or `total_increasing`, which represent an accumulated value, while `measurement` is supposed to represent an instant value.

Thanks to this change, I can now see my consumption directly in the "Energy" dashboard.

![2022-08-02_14-24](https://user-images.githubusercontent.com/17952318/182374003-5b0e9adb-dc11-4e56-9fa6-6e8a632b70dd.png)

More info: https://developers.home-assistant.io/docs/core/entity/sensor/#long-term-statistics